### PR TITLE
Fix #12 (finishing a destroyed surface)

### DIFF
--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -252,14 +252,17 @@ Finish the drawing, and close the file. You may be able to open it in an externa
 application with `preview()`.
 """
 function finish()
+    if currentdrawing.surface.ptr == C_NULL
+        # Already finished
+        return false
+    end
     if currentdrawing.surfacetype == "png"
         Cairo.write_to_png(currentdrawing.surface, currentdrawing.filename)
-        Cairo.finish(currentdrawing.surface)
-        Cairo.destroy(currentdrawing.surface)
-    else
-        Cairo.finish(currentdrawing.surface)
-        Cairo.destroy(currentdrawing.surface)
     end
+
+    Cairo.finish(currentdrawing.surface)
+    Cairo.destroy(currentdrawing.surface)
+
     return true
 end
 

--- a/test/luxor-test1.jl
+++ b/test/luxor-test1.jl
@@ -61,6 +61,9 @@ function draw_luxor_demo(fname)
 
     textcurve("THIS IS TEXT ON A CURVE " ^ 14, 0, 550, O)
     @test finish() == true
+
+    # Test that calling finish() twice doesn't segfault.
+    @test finish() == false
 end
 
 fname = "luxor-test1.png"


### PR DESCRIPTION
By ensuring that the surface hasn't been destroyed already before finishing and destroying it. Added test that calling finish twice doesn't cause a segfault.
Side note: Thanks to the creators of this package from this graphics tourist!