### PR TITLE
Override Base.show to show a drawing in IJulia when it is returned

### DIFF
--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -166,6 +166,17 @@ function Base.show(io::IO, d::Luxor.Drawing)
 """)
 end
 
+Base.mimewritable(::MIME"image/svg+xml",d::Luxor.Drawing) = d.surfacetype == "svg"
+Base.mimewritable(::MIME"image/png", d::Luxor.Drawing) = d.surfacetype == "png"
+
+function Base.show(f::IO, ::MIME"image/svg+xml", d::Luxor.Drawing)
+    write(f, readstring(d.filename))
+end
+
+function Base.show(f::IO, ::MIME"image/png", d::Luxor.Drawing)
+    write(f, read(d.filename))
+end
+
 """
 The `paper_sizes` Dictionary holds a few paper sizes, width is first, so default is Portrait:
 


### PR DESCRIPTION
This seems to operate better with Interact.jl, in the latest version using `preview` seems to remove the manipulators. Using the current proposal, the following works:

```julia
using Luxor
using Interact

function makecircle(r)
    d = Drawing(100,100,"test.svg")
    origin()
    circle(O,r,:stroke)
    finish()
    return d
end

@manipulate for r in 5:50
    makecircle(r)
end
```