### PR TITLE
Add abstract type to scene

### DIFF
--- a/src/animate.jl
+++ b/src/animate.jl
@@ -59,16 +59,21 @@ The Scene type defines a function to be used to render a range of frames in a mo
 - the `framefunction` is a function taking two arguments: the scene and the framenumber.
 - the `framerange` determines which frames are processed by the function. Defaults to the entire movie.
 - the optional `easingfunction` can be accessed by the framefunction to vary the transition speed
+- the optional `opts` which is a single argument of an abstract type which can be accessed within the framefunction
 """
 mutable struct Scene
     movie::Movie
     framefunction::Function
     framerange::AbstractRange
     easingfunction::Function
+    opts::Any
 end
 
-Scene(movie::Movie, framefunction::Function; easingfunction=lineartween) = Scene(movie, framefunction, movie.movieframerange, easingfunction)
-Scene(movie, framefunction, framerange; easingfunction=lineartween) = Scene(movie, framefunction, framerange, easingfunction)
+Scene(movie::Movie, framefunction::Function; easingfunction=lineartween) = Scene(movie, framefunction, movie.movieframerange, easingfunction, nothing)
+Scene(movie, framefunction, framerange; easingfunction=lineartween) = Scene(movie, framefunction, framerange, easingfunction, nothing)
+
+Scene(movie::Movie, framefunction::Function; easingfunction=lineartween, optarg=nothing) = Scene(movie, framefunction, movie.movieframerange, easingfunction, optarg)
+Scene(movie, framefunction, framerange; easingfunction=lineartween, optarg=nothing) = Scene(movie, framefunction, framerange, easingfunction, optarg)
 
 """
     animate(movie::Movie, scenelist::AbstractArray{Scene, 1};


### PR DESCRIPTION
Added optional argument to scene type to allow for more complex programatic access in frame construction.

This allows a scene function to generate more complex scenes, such as allowing for a random change between frames of an element. 