### PR TITLE
Auto add file extension & support `size(x, n)`

### DIFF
--- a/src/Table.jl
+++ b/src/Table.jl
@@ -210,6 +210,11 @@ function Base.size(t::Table)
     return (t.nrows, t.ncols)
 end
 
+function Base.size(t::Table, n::Int)
+    return n == 1 ? t.nrows :
+           n == 2 ? t.ncols : 1
+end
+
 function Base.length(t::Table)
     t.nrows * t.ncols
 end

--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -293,6 +293,13 @@ function preview()
     return returnvalue
 end
 
+function _add_ext(fname, ext)
+    if match(Regex("[^\\\\]*\\.$ext"), fname) === nothing
+        return join([fname, ".png"])
+    end
+    return fname
+end
+
 """
     @svg drawing-instructions [width] [height] [filename]
 
@@ -324,6 +331,7 @@ Examples
          end 1200, 1200
 """
 macro svg(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).svg")
+     _add_ext(fname, :svg)
      quote
         Drawing($width, $height, $fname)
         origin()
@@ -366,7 +374,8 @@ Examples
          end 1200 1200
 """
 macro png(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).png")
-     quote
+    _add_ext(fname, :png)
+    quote
         Drawing($width, $height, $fname)
         origin()
         background("white")
@@ -407,6 +416,7 @@ Examples
          end 1200, 1200
 """
 macro pdf(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).pdf")
+     _add_ext(fname, :pdf)
      quote
         Drawing($width, $height, $fname)
         origin()

--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -331,7 +331,7 @@ Examples
          end 1200, 1200
 """
 macro svg(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).svg")
-     _add_ext(fname, :svg)
+     fname = _add_ext(fname, :svg)
      quote
         Drawing($width, $height, $fname)
         origin()
@@ -374,7 +374,7 @@ Examples
          end 1200 1200
 """
 macro png(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).png")
-    _add_ext(fname, :png)
+    fname = _add_ext(fname, :png)
     quote
         Drawing($width, $height, $fname)
         origin()
@@ -416,7 +416,7 @@ Examples
          end 1200, 1200
 """
 macro pdf(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).pdf")
-     _add_ext(fname, :pdf)
+     fname = _add_ext(fname, :pdf)
      quote
         Drawing($width, $height, $fname)
         origin()


### PR DESCRIPTION
I think there's no need to let user type the file extension if they don't want to when there's one in macro already. 

And it is not intuitive when `size(t)` is supported, but `size(t, 1)`/`size(t, 2)` is not.