### PR TITLE
IJulia & Juno display fix

### DIFF
--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -90,10 +90,10 @@ current_bufferdata()      = getfield(CURRENTDRAWING[1], :bufferdata)
 
 function Base.show(io::IO, ::MIME"text/plain", d::Drawing)
     returnvalue = d.filename
-    # When the caller of `show` wants a short description, 
-    # we only print the filename.
-    if get(io, :limit, false)
-        print(io, returnvalue)
+    # IJulia and Juno call the `show` function twice: once for
+    # the image MIME and a second time for the text/plain MIME.
+    # We check if this is such a 'second call':
+    if (get(io, :jupyter, false) || Juno.isactive()) && (d.surfacetype == :svg || d.surfacetype == :png)
         return
     end
     # otherwise, we open the image file

--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -82,7 +82,7 @@ current_bufferdata()      = getfield(CURRENTDRAWING[1], :bufferdata)
 # are shortcuts to file-based drawings.) When a drawing is
 # finished, you go `finish()` (that's the last line of the
 # @... macros.). Then, if you want to actually see it, you
-# go `preview()`.
+# go `preview()`, which returns the current drawing.
 
 # Then the code has to decide where you're working, and what
 # type of file it is, then sends it to the right place,
@@ -90,6 +90,13 @@ current_bufferdata()      = getfield(CURRENTDRAWING[1], :bufferdata)
 
 function Base.show(io::IO, ::MIME"text/plain", d::Drawing)
     returnvalue = d.filename
+    # When the caller of `show` wants a short description, 
+    # we only print the filename.
+    if get(io, :limit, false)
+        print(io, returnvalue)
+        return
+    end
+    # otherwise, we open the image file
     if Sys.isapple()
         run(`open $(returnvalue)`)
     elseif Sys.iswindows()
@@ -98,8 +105,6 @@ function Base.show(io::IO, ::MIME"text/plain", d::Drawing)
     elseif Sys.isunix()
         run(`xdg-open $(returnvalue)`)
     end
-    # print(io, returnvalue)
-    nothing
 end
 
 function tidysvg(m::MIME"image/svg+xml", fname)
@@ -547,7 +552,7 @@ macro draw(body, width=600, height=600)
         sethue("black")
         $(esc(body))
         finish()
-        CURRENTDRAWING[1]
+        preview()
     end
 end
 


### PR DESCRIPTION
It turns out that IJulia and Juno call `show` _twice_, once with the `image/something` MIME type, and [once with the `text/plain` MIME type](https://github.com/JuliaLang/IJulia.jl/blob/master/src/inline.jl#L37). Strange!

This fix detects that the `text/plain` method is such a second call, and doesn't open a file in that case. It now works in the REPL, Pluto, Jupyter and Juno.

MIME types other than `png` or `svg` open a file in all environments.