### PR TITLE
Added convenience constructor

### DIFF
--- a/src/point.jl
+++ b/src/point.jl
@@ -37,6 +37,9 @@ const O = Point(0, 0)
 *(p1::Point, shift::NTuple{2, Real}) = Point(p1.x * shift[1], p1.y * shift[2])
 /(p1::Point, shift::NTuple{2, Real}) = Point(p1.x / shift[1], p1.y / shift[2])
 
+# convenience
+Point((x, y)::Tuple{Real, Real}) = Point(x, y)
+
 # for broadcasting
 Base.size(::Point) = 2
 Base.getindex(p::Point, i) = [p.x, p.y][i]

--- a/test/point-arithmetic.jl
+++ b/test/point-arithmetic.jl
@@ -16,6 +16,10 @@ function general_tests()
 
     @test -pt1 == Point(-pt1.x, -pt1.y)
 
+    # constructor with tuple
+    @test Point((1, 2)) == Point(1, 2)
+    @test [Point(3, 1), Point(4.0, 1.0), Point(2//3,3//4)] == Point.([(3.0, 1.0), (4, 1), (2//3,3//4)])
+
     # is point/4 inside a box
     # a: we now have to wrap arguments with Ref() to ensure they  broadcast as scalar
     @test isinside(Ref(pt1) ./ 4, box(O, 10, 10, vertices=true))


### PR DESCRIPTION
The purpose is a terse initialization of test arrays. Instead of writing:
```
pl = [Point(0, 0), Point(1, 1), Point(2, 0), Point(3, 0), Point(4, 0)]

```
one can write:
```
pl = Point.([(0, 0), (1, 1), (2, 0), (3, 0), (4, 0)])
```