### PR TITLE
[WIP] get_fontsize

### DIFF
--- a/docs/src/text.md
+++ b/docs/src/text.md
@@ -63,6 +63,7 @@ Use `fontface(fontname)` to choose a font, and `fontsize(n)` to set the font siz
 ```@docs
 fontface
 fontsize
+get_fontsize
 ```
 
 ## Specifying the font ("Pro" API)

--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -120,7 +120,7 @@ export Drawing,
 
     fontface, fontsize, text, textpath, label,
     textextents, textoutlines, textcurve, textcentred, textcentered, textright,
-    textcurvecentred, textcurvecentered,
+    textcurvecentred, textcurvecentered, get_fontsize,
     textwrap, textlines, splittext, textbox, texttrack,
 
     setcolor, setopacity, sethue, setgrey, setgray,

--- a/src/text.jl
+++ b/src/text.jl
@@ -13,7 +13,7 @@
     text(str, pos, valign=:baseline, halign=:left)
 
 Draw the text in the string `str` at `x`/`y` or `pt`, placing the start of the
-string at the point. If you omit the point, it's placed at the current `0/0`. 
+string at the point. If you omit the point, it's placed at the current `0/0`.
 
 `angle` specifies the rotation of the text relative to the current x-axis.
 
@@ -120,12 +120,19 @@ fontsize(n) = Cairo.set_font_size(get_current_cr(), n)
 """
     get_fontsize()
 
-Return the font size set by `fontsize` or more precisely the y-scale of the Cairo font matrix if `Cairo.set_font_matrix` is used directly. (Toy API)
+Return the font size set by `fontsize` or more precisely the y-scale of the Cairo font matrix
+if `Cairo.set_font_matrix` is used directly. (Toy API)
+
+> This only works if Cairo is at least at v1.0.5.
 """
 function get_fontsize()
-    m = get_font_matrix(get_current_cr())
-    font_size = sign(m.yy)*sqrt(m.yx^2+m.yy^2)
-    return font_size
+    if @isdefined get_font_matrix
+        m = get_font_matrix(get_current_cr())
+        font_size = sign(m.yy)*sqrt(m.yx^2+m.yy^2)
+        return font_size
+    else
+        throw(MethodError(get_fontsize, "Please use Cairo v1.0.5 or later to use this feature."))
+    end
 end
 
 """

--- a/src/text.jl
+++ b/src/text.jl
@@ -116,6 +116,18 @@ Set the font size to `n` points. The default size is 10 points. (Toy API)
 """
 fontsize(n) = Cairo.set_font_size(get_current_cr(), n)
 
+
+"""
+    get_fontsize()
+
+Return the font size set by `fontsize` or more precisely the y-scale of the Cairo font matrix if `Cairo.set_font_matrix` is used directly. (Toy API)
+"""
+function get_fontsize()
+    m = get_font_matrix(get_current_cr())
+    font_size = sign(m.yy)*sqrt(m.yx^2+m.yy^2)
+    return font_size
+end
+
 """
     textextents(str)
 

--- a/test/text-wrapping.jl
+++ b/test/text-wrapping.jl
@@ -18,9 +18,12 @@ function text_wrap_tests(fname)
         fsize = 12
         opacity = 1.0
         fontsize(fsize)
-        if @isdefined get_font_matrix
-            @test get_fontsize() == fsize
-        else
+        try
+            # does not work with Cairo < 1.0.5
+            recevied_fsize = get_fontsize()
+            @test recevied_fsize == fsize
+        catch
+            # should throw with Cairo < 1.0.5
             @test_throws MethodError get_fontsize()
         end
         @layer begin

--- a/test/text-wrapping.jl
+++ b/test/text-wrapping.jl
@@ -18,6 +18,7 @@ function text_wrap_tests(fname)
         fsize = 12
         opacity = 1.0
         fontsize(fsize)
+        @test get_fontsize() == fsize
         @layer begin
             translate(pos)
             sethue("antiquewhite")

--- a/test/text-wrapping.jl
+++ b/test/text-wrapping.jl
@@ -18,7 +18,11 @@ function text_wrap_tests(fname)
         fsize = 12
         opacity = 1.0
         fontsize(fsize)
-        @test get_fontsize() == fsize
+        if @isdefined get_font_matrix
+            @test get_fontsize() == fsize
+        else
+            @test_throws MethodError get_fontsize()
+        end
         @layer begin
             translate(pos)
             sethue("antiquewhite")


### PR DESCRIPTION
This should work when Cairo releases a new version. So I need to update the Project.toml `compat` section then. 
Maybe @cormullion can give feedback already whether that makes sense.

It seems like this is only working for the "toy" API.