### PR TITLE
removed some exports and renamed others

### DIFF
--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -78,14 +78,14 @@ export Drawing,
 
     move, rmove, line, rule, rline, arrow, arrowhead, dimension,
 
-    BoundingBox, boundingbox, boxwidth, boxheight, boxdiagonal, boxaspectratio,
+    BoundingBox, boxwidth, boxheight, boxdiagonal, boxaspectratio,
     boxtop, boxbottom, boxtopleft, boxtopcenter, boxtopright, boxmiddleleft,
     boxmiddlecenter, boxmiddleright, boxbottomleft, boxbottomcenter,
     boxbottomright,
 
     intersectboundingboxes, boundingboxesintersect, pointcrossesboundingbox,
 
-    Boxmaptile, boxmap,
+    BoxmapTile, boxmap,
 
     circle, circlepath, ellipse, hypotrochoid, epitrochoid, squircle, center3pts, curve,
     arc, carc, arc2r, carc2r, isarcclockwise, arc2sagitta, carc2sagitta,
@@ -148,7 +148,7 @@ export Drawing,
     mesh, setmesh, mask,
 
     # animation
-    Sequence, Movie, Scene, animate,
+    Movie, Scene, animate,
 
     lineartween, easeinquad, easeoutquad, easeinoutquad, easeincubic, easeoutcubic,
     easeinoutcubic, easeinquart, easeoutquart, easeinoutquart, easeinquint, easeoutquint,


### PR DESCRIPTION
If I see this correctly you currently export functions which don't exist "anymore".
Not sure whether you intend to export `BoxmapTile` but as you exported `Boxmaptile` I just renamed it.

