### PR TITLE
Fix macro hygeine of width and height

### DIFF
--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -409,7 +409,7 @@ Examples
 macro svg(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).svg")
     quote
         local lfname = _add_ext($(esc(fname)), :svg)
-        Drawing($width, $height, lfname)
+        Drawing($(esc(width)), $(esc(height)), lfname)
         origin()
         background("white")
         sethue("black")
@@ -456,7 +456,7 @@ Examples
 macro png(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).png")
     quote
         local lfname = _add_ext($(esc(fname)), :png)
-        Drawing($width, $height, lfname)
+        Drawing($(esc(width)), $(esc(height)), lfname)
         origin()
         background("white")
         sethue("black")
@@ -502,7 +502,7 @@ Examples
 macro pdf(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).pdf")
      quote
         local lfname = _add_ext($(esc(fname)), :pdf)
-        Drawing($width, $height, lfname)
+        Drawing($(esc(width)), $(esc(height)), lfname)
         origin()
         background("white")
         sethue("black")
@@ -550,7 +550,7 @@ Examples
 macro eps(body, width=600, height=600, fname="luxor-drawing-$(Dates.format(Dates.now(), "HHMMSS_s")).eps")
     quote
        local lfname = _add_ext($(esc(fname)), :eps)
-       Drawing($width, $height, lfname)
+        Drawing($(esc(width)), $(esc(height)), lfname)
         origin()
         background("white")
         sethue("black")
@@ -592,7 +592,7 @@ Examples
 """
 macro draw(body, width=600, height=600)
     quote
-        Drawing($width, $height, :png)
+        Drawing($(esc(width)), $(esc(height)), :png)
         origin()
         background("white")
         sethue("black")


### PR DESCRIPTION
Fixes #127. Julia was resolving `:width` and `:height` as being variables defined within Luxor, not user input so they needed to be `esc`'d. 

![image](https://user-images.githubusercontent.com/29157027/103808829-d26fa700-5015-11eb-8925-9e346f36192a.png)
