### PR TITLE
Bugfix for center3pts

### DIFF
--- a/src/curves.jl
+++ b/src/curves.jl
@@ -55,24 +55,21 @@ returns `(centerpoint, radius)` of a circle.
 
 If there's no such circle, the function returns `(Point(0, 0), 0)`.
 """
-function center3pts(a::Point, b::Point, c::Point)
-    midAB = midpoint(a, b)
-    perpAB = perpendicular(a - b)
-    midBC = midpoint(b, c)
-    perpBC = perpendicular(b - c)
-    # do the lines intersect?
-    crossp = crossproduct(perpAB, perpBC)
-    if isapprox(crossp, 0)
-        @debug "no circle passes through the points $a $b $c"
-        return Point(0, 0), 0
+function center3pts(p1::Point, p2::Point, p3::Point)
+    norm2(p::Point) = (p.x)^2+(p.y)^2
+
+    α1 = norm2(p3-p2)*(norm2(p2-p1)+norm2(p1-p3)-norm2(p3-p2))
+    α2 = norm2(p1-p3)*(norm2(p3-p2)+norm2(p2-p1)-norm2(p1-p3))
+    α3 = norm2(p2-p1)*(norm2(p1-p3)+norm2(p3-p2)-norm2(p2-p1))
+
+    if α1+α2+α3 ≠ 0.0
+        c = (α1*p1+α2*p2+α3*p3)/(α1+α2+α3)
+        r = √(norm2(p1-c))
+        return c, r
+    else
+        @warn "There are no circles which pass $p1, $p2 and $p3."
+        return (Point(0, 0), 0)
     end
-    centerX = ((midAB.y * perpAB.x * perpBC.x) +
-               (midBC.x * perpAB.x * perpBC.y) -
-               (midAB.x * perpAB.y * perpBC.x) -
-               (midBC.y * perpAB.x * perpBC.x)) / crossp
-    centerY = ((centerX - midAB.x) * perpAB.y / perpAB.x)  + midAB.y
-    radius = hypot(abs(centerX - a.x), abs(centerY - a.y))
-    return Point(centerX, centerY), radius
 end
 
 """

--- a/src/curves.jl
+++ b/src/curves.jl
@@ -67,7 +67,7 @@ function center3pts(p1::Point, p2::Point, p3::Point)
         r = √(norm2(p1-c))
         return c, r
     else
-        @warn "There are no circles which pass $p1, $p2 and $p3."
+        @warn "There are no circles which pass through $p1, $p2 and $p3."
         return (Point(0, 0), 0)
     end
 end

--- a/test/basic-test.jl
+++ b/test/basic-test.jl
@@ -1,4 +1,4 @@
-using Luxor, Test
+using Luxor, Test, Random
 
 
 # test empty drawings
@@ -21,6 +21,14 @@ rp = rand(bb)
 
 @test rp in bb
 
-@test center3pts(Point(1,1), Point(3,1), Point(2,0)) == (Point(2.0, 1.0), 1.0)
+@testset "center3pts" begin
+    @test center3pts(Point(1,1), Point(3,1), Point(2,0)) == (Point(2.0, 1.0), 1.0)
+    Random.seed!(42)
+    p1 = Point(rand(), rand())
+    p2 = Point(rand(), rand())
+    p3 = Point(rand(), rand())
+    c, r = center3pts(p1, p2, p3)
+    @test distance(p1, c) ≈ distance(p2, c) ≈ distance(p2, c)
+end
 
 println("...finished basic-test")

--- a/test/basic-test.jl
+++ b/test/basic-test.jl
@@ -21,4 +21,6 @@ rp = rand(bb)
 
 @test rp in bb
 
+@test center3pts(Point(1,1), Point(3,1), Point(2,0)) == (Point(2.0, 1.0), 1.0)
+
 println("...finished basic-test")


### PR DESCRIPTION
Fix #131.

* Fix the `NaN` issue.
* Add test for `center3pts`
* Throw warning when a center of circle doesn't exists in Euclid plane.

```julia
julia> using Luxor

julia> Luxor.center3pts(Point(1,1), Point(3,1.0000001), Point(2,0))
(Point(2.0000000000000027, 1.0000000000000027), 1.0000000000000027)

julia> Luxor.center3pts(Point(1,1), Point(3,1), Point(2,0))
(Point(2.0, 1.0), 1.0)

julia> Luxor.center3pts(O, O, O)
┌ Warning: There's no circle which pass Point(0.0, 0.0), Point(0.0, 0.0) and Point(0.0, 0.0).
└ @ Luxor ~/.julia/dev/Luxor/src/curves.jl:70
(Point(0.0, 0.0), 0)
```

Reference for the formula:
[「n+1点を通るn-1次元球面」 "n-1 dimensional sphere which passes given n+1 points"](https://hyrodium.github.io/pdf/#n1%E7%82%B9%E3%82%92%E9%80%9A%E3%82%8Bn-1%E6%AC%A1%E5%85%83%E7%90%83%E9%9D%A2)