### PR TITLE
svg Drawing placeimage support (unfinished)

### DIFF
--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -147,7 +147,7 @@ export Drawing,
 
     Table, highlightcells,
 
-    readpng, readsvg, placeimage,
+    readpng, readsvg, readsvgstring, placeimage,
 
     julialogo, juliacircles,
 

--- a/src/images.jl
+++ b/src/images.jl
@@ -51,7 +51,7 @@ Place the top left corner of the PNG image on the drawing at `pos`.
 
 Use keyword `centered=true` to place the center of the image at the position.
 """
-placeimage(img::Cairo.CairoSurface, pt::Point; kwargs...) = placeimage(img, pt.x, pt.y; kwargs...)
+placeimage(img::Cairo.CairoSurface, pt::Point=O; kwargs...) = placeimage(img, pt.x, pt.y; kwargs...)
 
 """
     placeimage(img, xpos, ypos, a; centered=false)
@@ -116,6 +116,20 @@ function readsvg(fname)
     SVGimage(r, d.em, d.ex, d.width, d.height)
 end
 
+function _readsvg_string(str)
+    r = Rsvg.handle_new_from_data(str)
+
+    if r.ptr == C_NULL
+        throw(error("readsvg_string(): some error message "))
+    end
+
+    d = Rsvg.handle_get_dimensions(r)
+    if iszero(d.width) || iszero(d.height)
+        throw(error("readsvg_string(): can't get dimensions from this SVG image. Either it's not a valid SVG file, or the format is different from what I'm expecting."))
+    end
+    return SVGimage(r, d.em, d.ex, d.width, d.height)
+end
+
 """
     placeimage(svgimg, pos; centered=false)
 
@@ -123,8 +137,7 @@ Place an SVG image on the drawing at `pos`. Use `readsvg()` to read an SVG image
 
 Use keyword `centered=true` to place the center of the image at the position.
 """
-function placeimage(im::SVGimage, pos;
-        centered=false)
+function placeimage(im::SVGimage, pos=O; centered=false)
     if centered == true
         w, h = im.width, im.height
         pos = pos - ((w/2), (h/2))
@@ -152,3 +165,11 @@ function placeimage(buffer::AbstractMatrix{UInt32}, pt=O; centered=false)
 end
 placeimage(buffer::AbstractMatrix{ARGB32}, args...; kargs...) = placeimage(collect(reinterpret(UInt32, buffer)), args...; kargs...)
 placeimage(buffer::AbstractMatrix{<:Colorant}, args...; kargs...) = placeimage(convert.(ARGB32, buffer), args...; kargs...)
+
+function placeimage(buffer::Drawing, args...; kargs...) 
+    if buffer.surfacetype == :svg
+        placeimage(_readsvg_string(String(copy(buffer.bufferdata))), args...; kargs...)
+    else
+        throw(error("surfacetype `$(buffer.surfacetype)` is not supported. use `image` instead"))
+    end
+end

--- a/src/images.jl
+++ b/src/images.jl
@@ -116,7 +116,7 @@ function readsvg(fname)
     SVGimage(r, d.em, d.ex, d.width, d.height)
 end
 
-function _readsvg_string(str)
+function readsvgstring(str)
     r = Rsvg.handle_new_from_data(str)
 
     if r.ptr == C_NULL
@@ -168,7 +168,7 @@ placeimage(buffer::AbstractMatrix{<:Colorant}, args...; kargs...) = placeimage(c
 
 function placeimage(buffer::Drawing, args...; kargs...) 
     if buffer.surfacetype == :svg
-        placeimage(_readsvg_string(String(copy(buffer.bufferdata))), args...; kargs...)
+        placeimage(readsvgstring(String(copy(buffer.bufferdata))), args...; kargs...)
     else
         throw(error("surfacetype `$(buffer.surfacetype)` is not supported. use `image` instead"))
     end


### PR DESCRIPTION
See https://github.com/JuliaGraphics/Luxor.jl/issues/134
This is an incomplete support.
First, png Drawing is not supported.
Second, the svg alpha background is not handled properly.
That is:
```julia
using Luxor # master 
m1 = @svg  begin
    background(0,0,0,0)
    juliacircles(10) 
end 40 40

@draw begin
    for i in 1:50
        pos = rand(BoundingBox())
        @layer begin
            translate(pos)
            rotate(rand() * 2π)
            placeimage(m1, centered = rand(Bool))   # <-
        end
    end
end 100 100
```
->
![图片](https://user-images.githubusercontent.com/55872791/105357640-0fe84d00-5c30-11eb-96a1-b9401cf110e3.png)
