### PR TITLE
import Base64 to fix gif display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["cormullion <cormullion@mac.com>"]
 version = "2.9.0"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -10,7 +10,7 @@ end
 """
 module Luxor
 
-using Juno, Cairo, Colors, FileIO, Dates, Rsvg
+using Juno, Cairo, Colors, FileIO, Base64, Dates, Rsvg
 
 #= from Cairo use: CairoARGBSurface, CairoEPSSurface, CairoMatrix, CairoPDFSurface, CairoPattern, CairoPatternMesh, CairoSurface, CairoSVGSurface,
 CairoContext, arc, arc_negative, circle, clip, clip_preserve, close_path,


### PR DESCRIPTION
Before:

<img width="567" alt="Schermafbeelding 2021-02-17 om 14 28 09" src="https://user-images.githubusercontent.com/6933510/108211542-1386cb00-712d-11eb-9f60-36838ad76bb7.png">

Which points here: https://github.com/fonsp/Luxor.jl/blob/229768b73e25b7b37f5088a70a5cb2264019abc9/src/animate.jl#L236

After:

https://user-images.githubusercontent.com/6933510/108211523-0ec21700-712d-11eb-8d01-d8ec01567032.mov

