### PR TITLE
Add support for stroke scaling via Cairo.stroke_transformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v2.14.0] - 2021-07-15
+
+### Added
+
+- setstrokescale() - enable/disable stroke scaling
+
+### Changed
+
+- Drawing takes a boolean named argument `strokescale` to enable/disable stroke scaling
+
+### Removed
+
+### Deprecated
+
 ## [v2.13.0] - 2021-07-06
 
 ### Added
@@ -12,7 +26,7 @@
 
 - `polyportion()`/`polyremainder()` now throw error for single-point polys (duh)
 - BoundingBox() no longer fails if there's no drawing (returns a default value)
-- documentation restructed along divio ("grand unified theory of documentation" lines
+- documentation restructured along divio ("grand unified theory of documentation" lines
 
 ### Removed
 

--- a/docs/src/explanation/transforms.md
+++ b/docs/src/explanation/transforms.md
@@ -84,14 +84,7 @@ To return home after many changes, you can use [`setmatrix([1, 0, 0, 1, 0, 0])` 
 
 ## Scaling of lines
 
-Line thicknesses are not scaled. For example, with a current line thickness set by `setline(1)`, lines drawn before and after `scale(2)` will be the same thickness. If you want line thicknesses to respond to the current scale, so that lines change thickness after calls to `scale(n)`, you could define your own `strokeraw` function that calls the `cairo_stroke` primitive directly:
-
-```
-import Cairo
-function strokeraw()
-    ccall((:cairo_stroke, Cairo._jl_libcairo), Nothing, (Ptr{Nothing},), Luxor.get_current_cr().ptr)
-end
-```
+Line thicknesses are not scaled by default. For example, with a current line thickness set by `setline(1)`, lines drawn before and after `scale(2)` will be the same thickness. If you want line thicknesses to respond to the current scale, so that lines change thickness after calls to `scale(n)`, you can call `setstrokescale(true)` to enable stroke scaling, and `setstrokescale(false}` to disable it. You can also enable stroke scaling when creating a new `Drawing` by passing the named argument `strokescale` during `Drawing` construction (i.e., `Drawing(400, 400, strokescale=true)`).
 
 # Matrices
 

--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -81,7 +81,7 @@ export Drawing,
 
     rect, box, cropmarks,
 
-    setantialias, setline, setlinecap, setlinejoin, setdash,
+    setantialias, setline, setlinecap, setlinejoin, setdash, setstrokescale,
 
     move, rmove, line, rule, rline, arrow, arrowhead, dimension,
 
@@ -100,7 +100,7 @@ export Drawing,
     intersection_line_circle, intersectionlinecircle, intersectioncirclecircle, ispointonline,
     intersectlinepoly, polyintersect, polyintersections, circlepointtangent,
     circletangent2circles, pointinverse, pointcircletangent, circlecircleoutertangents,
-    circlecircleinnertangents, ellipseinquad, crescent, 
+    circlecircleinnertangents, ellipseinquad, crescent,
 
     ngon, ngonside, star, pie, polycross,
     do_action, paint, paint_with_alpha, fillstroke,

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -156,10 +156,10 @@ closepath() = Cairo.close_path(get_current_cr())
 """
     strokepath()
 
-Stroke the current path with the current line width, line join, line cap, and
-dash settings. The current path is then cleared.
+Stroke the current path with the current line width, line join, line cap, dash,
+and stroke scaling settings. The current path is then cleared.
 """
-strokepath() = Cairo.stroke(get_current_cr())
+strokepath() = get_current_strokescale() ? Cairo.stroke_transformed(get_current_cr()) : Cairo.stroke(get_current_cr())
 
 """
     fillpath()
@@ -178,10 +178,10 @@ paint() = Cairo.paint(get_current_cr())
 """
     strokepreserve()
 
-Stroke the current path with current line width, line join, line cap, and dash
-settings, but then keep the path current.
+Stroke the current path with current line width, line join, line cap, dash, and
+stroke scaling settings, but then keep the path current.
 """
-strokepreserve()    = Cairo.stroke_preserve(get_current_cr())
+strokepreserve()    = get_current_strokescale() ? Cairo.stroke_preserve_transformed(get_current_cr()) : Cairo.stroke_preserve(get_current_cr())
 
 """
     fillpreserve()
@@ -327,6 +327,23 @@ function setdash(dashes::Vector, offset=0.0)
     # no negative dashes
     Cairo.set_dash(get_current_cr(), abs.(Float64.(dashes)), offset)
 end
+
+
+"""
+    setstrokescale()
+
+Return the current stroke scaling setting.
+"""
+setstrokescale() = get_current_strokescale()
+
+
+"""
+    setstrokescale(state::Bool)
+
+Enable/disable stroke scaling for the current drawing.
+"""
+setstrokescale(state::Bool) = set_current_strokescale(state)
+
 
 """
     move(pt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,6 +159,7 @@ function run_all_tests()
         include("dashtests.jl")
         include("triangles.jl")
         include("place-svg.jl")
+        include("strokescale-test.jl")
     end
 end
 

--- a/test/strokescale-test.jl
+++ b/test/strokescale-test.jl
@@ -1,0 +1,43 @@
+using Luxor, Test, Colors
+
+function strokescale()
+    Drawing(10, 10, :png, strokescale=true)
+
+    # was the scale set correctly when the Drawing was created?
+    @test setstrokescale() == true
+
+    background("white")
+    setcolor(0, 0, 0)
+
+    # scale the canvas to use coordinates [0, 1]
+    scale(10)
+
+    # set our stroke width to the width of the canvas
+    setline(1)
+
+    # a line the width of the canvas drawn at 0 should cover 50% of the canvas
+    line(Point(0, 0), Point(0, 1), :stroke)
+
+    mat = image_as_matrix()
+    @test RGBA{Float32}(0, 0, 0, 1) == convert(RGBA{Float32}, mat[5, 3])
+
+    background("white")
+
+    setstrokescale(false)
+    @test setstrokescale() == false
+
+    # set our stroke width to size 1, independent of scaling
+    setline(1)
+
+    # An unscaled line of size 1 will not cover 50% of the canvas
+    line(Point(0, 0), Point(0, 1), :stroke)
+    mat = image_as_matrix()
+
+    # assert that the same pixel is now white
+    @test RGBA{Float32}(1, 1, 1, 1) == convert(RGBA{Float32}, mat[5, 3])
+    @test finish() == true
+end
+
+strokescale()
+
+println("...finished strokescaletest")


### PR DESCRIPTION
- Add new named parameter "strokescale" to constructor
- Add setstrokescale() and setstrokescale(Bool) functions
- Modify behavior of strokepath and stroke_preserve to delegate
  to the appropriate Cairo method based on strokescale setting.