### PR TITLE
Remove the shackles of ImageMagick

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,7 @@ Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rsvg = "c4c386cf-5103-5370-be45-f3a111cca3b8"
 
@@ -21,14 +19,13 @@ Cairo = "0.7, 0.8, 1.0"
 Colors = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 1.0"
 FFMPEG = "0.4"
 FileIO = "1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11"
-ImageMagick = "0.7, 1.0, 1.1, 1.2"
 Juno = "0.7, 0.8"
-QuartzImageIO = "0.6, 0.7"
 Rsvg = "1.0"
 julia = "1.3"
 
 [extras]
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ImageIO", "Test"]


### PR DESCRIPTION
ImageMagick has largely been supplanted by ImageIO.
I also thought I'd see what you thought about avoiding being
"opinionated" about which specific IO packages are best,
so I moved such dependencies to [extras]. But we could move
such dependencies back to [deps] if you're worried about
providing an out-of-box experience that "just works" without
the user having to choose specific IO package(s).

xrefs:
- https://github.com/JuliaIO/PNGFiles.jl/pull/45
- https://github.com/JuliaIO/FileIO.jl/issues/352