### PR TITLE
correct implementation of simplify

### DIFF
--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -156,9 +156,7 @@ function douglas_peucker(pointlist::Array{Point, 1}, start_index, last_index, ep
             push!(temp_stack, (start_index, index))
             push!(temp_stack, (index, last_index))
         else
-            for i in start_index + 2:last_index - 1 # 2 seems to keep the starting point...
-                keep_list[i - global_start_index] = false
-            end
+            keep_list[global_start_index + start_index: global_start_index+last_index-2] .= false
         end
     end
     return pointlist[keep_list]

--- a/test/simplify-polygons.jl
+++ b/test/simplify-polygons.jl
@@ -58,4 +58,13 @@ function simplify_poly(fname)
     println("...finished test: output in $(fname)")
 end
 
+function simplify_cube()
+    poly = Point[Point(-1.0, 0.0), Point(-1.0, -1.0), Point(0.0, -1.0), Point(1.0, -1.0), Point(1.0, 0.0), Point(1.0, 1.0), Point(0.0, 1.0), Point(-1.0, 1.0)]
+
+    poly = simplify(poly, 0.01)
+    @test poly == Point[Point(-1.0, 0.0), Point(-1.0, -1.0), Point(1.0, -1.0), Point(1.0, 1.0), Point(-1.0, 1.0)]
+end
+
 simplify_poly("simplify-poly.pdf")
+
+simplify_cube()

--- a/test/simplify-polygons.jl
+++ b/test/simplify-polygons.jl
@@ -58,7 +58,7 @@ function simplify_poly(fname)
     println("...finished test: output in $(fname)")
 end
 
-function simplify_cube()
+function simplify_square()
     poly = Point[Point(-1.0, 0.0), Point(-1.0, -1.0), Point(0.0, -1.0), Point(1.0, -1.0), Point(1.0, 0.0), Point(1.0, 1.0), Point(0.0, 1.0), Point(-1.0, 1.0)]
 
     poly = simplify(poly, 0.01)
@@ -67,4 +67,4 @@ end
 
 simplify_poly("simplify-poly.pdf")
 
-simplify_cube()
+simplify_square()


### PR DESCRIPTION
Hi @cormullion ,
I think there is currently a bug in the simplify method. This is my attempt to fix it :smile: 
I've also added a small test case for it which would have failed previously.

The keep list seems to have an off by one error and with broadcasting I think it's a bit simpler to read. Not sure whether there is a use case of calling `douglas_peucker` with start point different to `1` as I think it would be easier to read without the `global_start_index`. 