### PR TITLE
Drop support versions of Julia under `v1.6`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.3"
+          - "1.6"
           - "1"
           - "nightly"
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Juno = "0.7, 0.8"
 Rsvg = "1.0"
 Requires = "1"
 LaTeXStrings = "1.1, 1.2, 1.3"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"

--- a/src/Luxor.jl
+++ b/src/Luxor.jl
@@ -235,9 +235,4 @@ const inch = 72.0
 const cm = 28.3464566929
 const mm = 2.83464566929
 
-if VERSION >= v"1.1"   # work around https://github.com/JuliaLang/julia/issues/34121
-    include("precompile.jl")
-    _precompile_()
-end
-
 end # module

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1564,7 +1564,7 @@ function polyhull(points)
     end
     # find a point with the highest Y coordinate value
 
-    if VERSION > v"1.5.0"
+    if VERSION ≥ v"1.7.0"
         _, anchorindex = findmax(pt -> pt.y, points)
     else
         anchorindex = let

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,12 +174,7 @@ function run_all_tests()
 end
 
 if get(ENV, "LUXOR_KEEP_TEST_RESULTS", false) == "true"
-        # they changed mktempdir in v1.3
-        if VERSION <= v"1.2"
-            cd(mktempdir())
-        else
-            cd(mktempdir(cleanup=false))
-        end
+        cd(mktempdir(cleanup=false))
         @info("...Keeping the results in: $(pwd())")
         run_all_tests()
         @info("Test images were saved in: $(pwd())")


### PR DESCRIPTION
`v1.6` is the latest LTS version, so I thought it would be better to replace `1.3` with `1.6`.