### PR TITLE
Fix spacings in scripts

### DIFF
--- a/docs/src/assets/luxor-docs.css
+++ b/docs/src/assets/luxor-docs.css
@@ -1,12 +1,12 @@
 @font-face {
-	font-family: JuliaMono;
-	src:
-		local('JuliaMono'),
-		url("https://cdn.jsdelivr.net/gh/cormullion/juliamono/webfonts/JuliaMono-Regular.woff2");
+    font-family: JuliaMono;
+    src:
+        local('JuliaMono'),
+        url("https://cdn.jsdelivr.net/gh/cormullion/juliamono/webfonts/JuliaMono-Regular.woff2");
 }
 
 pre, code {
-	font-family: JuliaMono !important;
+    font-family: JuliaMono !important;
     font-feature-settings: "calt" 1;
 }
 
@@ -28,14 +28,14 @@ p > a:after {
 }
 
 html.theme--documenter-dark p > code {
-	  	color: #eff !important;
+    color: #eff !important;
 }
 
 html.theme--documenter-dark li > code {
-	  	color: #eff !important;
+    color: #eff !important;
 }
 
 
 html.theme--documenter-dark a > code {
-	  	color: #eff !important;
+    color: #eff !important;
 }

--- a/docs/src/example/examples.md
+++ b/docs/src/example/examples.md
@@ -166,7 +166,7 @@ function draw(n)
     sierpinski(points, n)
 end
 
-depth = 8 # 12 is ok, 20 is right out (on my computer, at least)
+depth = 8 # 12 is ok, 20 is right out (on my computer, at least)
 cols = distinguishable_colors(depth) # from Colors.jl
 draw(depth)
 

--- a/docs/src/howto/animation.md
+++ b/docs/src/howto/animation.md
@@ -165,7 +165,7 @@ function.
 
 
 |List of easing functions|
-|:---	                 |
+|:---                    |
 |easingflat|
 |lineartween|
 |easeinquad|

--- a/docs/src/howto/colors-styles.md
+++ b/docs/src/howto/colors-styles.md
@@ -595,12 +595,12 @@ col2 = RGB(rand(), rand(), rand())
 col3 = RGB(rand(), rand(), rand())
 col4 = RGB(rand(), rand(), rand())
 for (pos, n) in tiles
-	bx = box(
-		pos - (tiles.tilewidth/2, tiles.tileheight/2),
-		pos + (tiles.tilewidth/2, tiles.tileheight/2),
-		vertices = true)
-	add_mesh_patch(the_mesh, bx,
-	 	Random.shuffle!([col1, col2, col3, col4]))
+    bx = box(
+        pos - (tiles.tilewidth/2, tiles.tileheight/2),
+        pos + (tiles.tilewidth/2, tiles.tileheight/2),
+        vertices = true)
+    add_mesh_patch(the_mesh, bx,
+        Random.shuffle!([col1, col2, col3, col4]))
 end
 setmesh(the_mesh)
 paint()

--- a/docs/src/howto/createdrawings.md
+++ b/docs/src/howto/createdrawings.md
@@ -144,12 +144,12 @@ using Luxor, PlutoUI, Colors
 @bind y Slider(1:12)
 
 @draw begin
-	setopacity(0.8)
-	for i in 0:0.1:1
-		sethue(HSB(360i, .8, .8))
-		squircle(O, 50, 50, :fill, rt = x * i)
-		rotate(2π/y)
-	end
+    setopacity(0.8)
+    for i in 0:0.1:1
+        sethue(HSB(360i, .8, .8))
+        squircle(O, 50, 50, :fill, rt = x * i)
+        rotate(2π/y)
+    end
 end 100 100
 ```
 
@@ -159,14 +159,14 @@ or
 begin
     d = Drawing(800, 800, :svg)
     origin()
-	for (n, m) in enumerate(exp10.(range(0.0, 2, step=0.2)))
-		setmesh(mesh(convert(Vector{Point}, BoundingBox()/m),
-			["darkviolet","gold2", "firebrick2", "slateblue4"]))
-    	rotate(π/7)
-    	paint()
-	end
+    for (n, m) in enumerate(exp10.(range(0.0, 2, step=0.2)))
+        setmesh(mesh(convert(Vector{Point}, BoundingBox()/m),
+            ["darkviolet","gold2", "firebrick2", "slateblue4"]))
+        rotate(π/7)
+        paint()
+    end
     finish()
-	d
+    d
 end
 ```
 

--- a/docs/src/howto/polygons.md
+++ b/docs/src/howto/polygons.md
@@ -10,34 +10,34 @@ You can store a path in a Path type, which contains path elements.
 
 Luxor also provides a BezierPath type, which is an array of four-point tuples, each of which is a Bézier cubic curve section.
 
-|create                         |convert                 		|draw                   	|info                     	|edit                           |
-|:---	                        |:---	                 		|:---	                	|:---	                  	|:---                           |
-| *polygons*                    |                        		|                       	|				          	|                               |
-|[`ngon`](@ref)                 |[`polysmooth`](@ref)    		|[`poly`](@ref)         	|[`isinside`](@ref)       	|[`simplify`](@ref)             |
-|[`ngonside`](@ref)             |[`polytopath`](@ref)     		|[`prettypoly`](@ref)   	|[`polyperimeter`](@ref)  	|[`polysplit`](@ref)            |
-|[`star`](@ref)                 |                        		|[`polysmooth`](@ref)   	|[`polyarea`](@ref)       	|[`polyportion`](@ref)          |
-|[`polycross`](@ref)            |                        		|                       	|[`polycentroid`](@ref)   	|[`polyremainder`](@ref)        |
-|[`offsetpoly`](@ref)           |                        		|                       	|[`BoundingBox`](@ref)     	|[`polysortbyangle`](@ref)      |
-|[`hypotrochoid`](@ref)         |                        		|                       	|[`ispolyclockwise`](@ref)  |[`polysortbydistance`](@ref)   |
-|[`epitrochoid`](@ref)          |                        		|                       	|[`ispolyconvex`](@ref)     |[`polyintersections`](@ref)    |
-|[`polyrotate!`](@ref)          |                        		|                       	|[`ispointonpoly`](@ref)    |[`polymove!`](@ref)            |
-|[`polyfit`](@ref)              |                        		|                       	|				   			|[`polyscale!`](@ref)           |
-|[`polyhull`](@ref)             |                        		|                       	|				   			|                               |
-|                               |                        		|                       	|				   			|[`polyreflect!`](@ref)         |
-|                               |                        		|                       	|				   			|[`polysample`](@ref)           |
-|                               |                        		|                       	|				   			|[`polytriangulate`](@ref)      |
-|                               |                        		|                       	|				   			|[`insertvertices!`](@ref)      |
-|                               |                        		|                       	|				   			|[`polymorph`](@ref)           |
-| *paths*                       |                        		|                       	|				   			|                               |
-|[`storepath`](@ref)            |                        		|                       	|				   			|                               |
-|[`getpath`](@ref)              |[`pathtopoly`](@ref)    		|[`drawpath`](@ref)         |[`pathlength`](@ref)       |[`pathsample`](@ref)           |
-|[`getpathflat`](@ref)          |                        		|                       	|				   			|                               |
-| *Bezier paths*                |                        		|                       	|				   			|                               |
-|[`makebezierpath`](@ref)       |[`pathtobezierpaths`](@ref)  	|[`drawbezierpath`](@ref)   |                  			|[`trimbezier`](@ref)           |
-|[`pathtobezierpaths`](@ref)    |[`bezierpathtopoly`](@ref)   	|[`brush`](@ref)            |                  			|[`splitbezier`](@ref)          |
-|`BezierPath`                   |[`bezierpathtopath`](@ref) 	|                           |                  			|                               |
-|`BezierPathSegment`            |                        		|                           |                  			|                               |
-|[`beziersegmentangles`](@ref)  |                        		|                           |                  			|                               |
+|create                         |convert                        |draw                       |info                       |edit                           |
+|:---                           |:---                           |:---                       |:---                       |:---                           |
+| *polygons*                    |                               |                           |                           |                               |
+|[`ngon`](@ref)                 |[`polysmooth`](@ref)           |[`poly`](@ref)             |[`isinside`](@ref)         |[`simplify`](@ref)             |
+|[`ngonside`](@ref)             |[`polytopath`](@ref)           |[`prettypoly`](@ref)       |[`polyperimeter`](@ref)    |[`polysplit`](@ref)            |
+|[`star`](@ref)                 |                               |[`polysmooth`](@ref)       |[`polyarea`](@ref)         |[`polyportion`](@ref)          |
+|[`polycross`](@ref)            |                               |                           |[`polycentroid`](@ref)     |[`polyremainder`](@ref)        |
+|[`offsetpoly`](@ref)           |                               |                           |[`BoundingBox`](@ref)      |[`polysortbyangle`](@ref)      |
+|[`hypotrochoid`](@ref)         |                               |                           |[`ispolyclockwise`](@ref)  |[`polysortbydistance`](@ref)   |
+|[`epitrochoid`](@ref)          |                               |                           |[`ispolyconvex`](@ref)     |[`polyintersections`](@ref)    |
+|[`polyrotate!`](@ref)          |                               |                           |[`ispointonpoly`](@ref)    |[`polymove!`](@ref)            |
+|[`polyfit`](@ref)              |                               |                           |                           |[`polyscale!`](@ref)           |
+|[`polyhull`](@ref)             |                               |                           |                           |                               |
+|                               |                               |                           |                           |[`polyreflect!`](@ref)         |
+|                               |                               |                           |                           |[`polysample`](@ref)           |
+|                               |                               |                           |                           |[`polytriangulate`](@ref)      |
+|                               |                               |                           |                           |[`insertvertices!`](@ref)      |
+|                               |                               |                           |                           |[`polymorph`](@ref)            |
+| *paths*                       |                               |                           |                           |                               |
+|[`storepath`](@ref)            |                               |                           |                           |                               |
+|[`getpath`](@ref)              |[`pathtopoly`](@ref)           |[`drawpath`](@ref)         |[`pathlength`](@ref)       |[`pathsample`](@ref)           |
+|[`getpathflat`](@ref)          |                               |                           |                           |                               |
+| *Bezier paths*                |                               |                           |                           |                               |
+|[`makebezierpath`](@ref)       |[`pathtobezierpaths`](@ref)    |[`drawbezierpath`](@ref)   |                           |[`trimbezier`](@ref)           |
+|[`pathtobezierpaths`](@ref)    |[`bezierpathtopoly`](@ref)     |[`brush`](@ref)            |                           |[`splitbezier`](@ref)          |
+|`BezierPath`                   |[`bezierpathtopath`](@ref)     |                           |                           |                               |
+|`BezierPathSegment`            |                               |                           |                           |                               |
+|[`beziersegmentangles`](@ref)  |                               |                           |                           |                               |
 
 ## Regular polygons ("ngons")
 

--- a/docs/src/howto/polygons.md
+++ b/docs/src/howto/polygons.md
@@ -1131,7 +1131,7 @@ Drawing(600, 250, "../assets/figures/insertvertices.png") # hide
 origin() # hide
 background("white") # hide
 setline(1) # hide
-sethue("black") # hide
+sethue("black") # hide
 
 pts = box(O, 500, 200, vertices=true)
 prettypoly(pts, :stroke, close=true)
@@ -1158,7 +1158,7 @@ Drawing(600, 250, "../assets/figures/polysample.png") # hide
 origin() # hide
 background("white") # hide
 setline(1) # hide
-sethue("black") # hide
+sethue("black") # hide
 
 pts = ngon(O, 100, 4, vertices=true)
 for (n, npoints) in enumerate(reverse([4, 8, 16, 32, 48]))
@@ -1183,12 +1183,12 @@ Drawing(600, 250, "../assets/figures/polysample2.png") # hide
 origin() # hide
 background("white") # hide
 setline(1) # hide
-sethue("black") # hide
-fontsize(8) # hide
+sethue("black") # hide
+fontsize(8) # hide
 
-translate(0, -50) # hide
+translate(0, -50) # hide
 setline(1) # hide
-sethue("black") # hide
+sethue("black") # hide
 
 # original polygon
 

--- a/docs/src/howto/text.md
+++ b/docs/src/howto/text.md
@@ -288,11 +288,11 @@ Use `textcurve(str)` to draw a string `str` on a circular arc or spiral.
 
 ```@example
 using Luxor # hide
-Drawing(800, 800, "../assets/figures/text-spiral.png") # hide
+Drawing(800, 800, "../assets/figures/text-spiral.png") # hide
 
-origin() # hide
-background("ivory") # hide
-sethue("royalblue4") # hide
+origin() # hide
+background("ivory") # hide
+sethue("royalblue4") # hide
 fontsize(7)
 fontface("Menlo")
 textstring = join(names(Base), " ")
@@ -305,7 +305,7 @@ textcurve("this spiral contains every word in julia names(Base): " * textstring,
 fontsize(35)
 fontface("Avenir-Black")
 textcentered("julia names(Base)", 0, 0)
-finish() # hide
+finish() # hide
 
 nothing # hide
 ```
@@ -393,14 +393,14 @@ Drawing(currentwidth, currentheight, "/tmp/text-path-clipping.png")
 origin()
 background("darkslategray3")
 
-fontsize(600)                             # big fontsize to use for clipping
+fontsize(600)                             # big fontsize to use for clipping
 fontface("Agenda-Black")
 str = "julia"                             # string to be clipped
-w, h = textextents(str)[3:4]              # get width and height
+w, h = textextents(str)[3:4]              # get width and height
 
 translate(-(currentwidth/2) + 50, -(currentheight/2) + h)
 
-textpath(str)                             # make text into a path
+textpath(str)                             # make text into a path
 setline(3)
 setcolor("black")
 fillpreserve()                            # fill but keep
@@ -408,7 +408,7 @@ clip()                                    # and use for clipping region
 
 fontface("Monaco")
 fontsize(10)
-namelist = map(x->string(x), names(Base)) # get list of function names in Base.
+namelist = map(x->string(x), names(Base)) # get list of function names in Base.
 
 let
     x = -20

--- a/src/Boxmaptile.jl
+++ b/src/Boxmaptile.jl
@@ -138,7 +138,7 @@ end 400 400 "boxmap.svg"
 """
 function boxmap(A::Array, pt::Point, w, h)
     # algorithm basically from Bruls, Huizing, van Wijk, "Squarified Treemaps"
-    # without the silly name
+    # without the silly name
     !all(n -> n > 0, A) && error("all values must be positive")
     sort!(A, rev=true)
     totalvalue = sum(A)

--- a/src/Turtle.jl
+++ b/src/Turtle.jl
@@ -37,8 +37,8 @@ mutable struct Turtle
     xpos::Float64
     ypos::Float64
     pendown::Bool
-    orientation::Float64 # stored in radians but set in degrees
-    pencolor::Tuple{Float64, Float64, Float64} # it's an RGB turtle
+    orientation::Float64 # stored in radians but set in degrees
+    pencolor::Tuple{Float64, Float64, Float64} # it's an RGB turtle
     function Turtle(xpos, ypos, pendown::Bool, orientation, pencolor=(0.0, 0.0, 0.0))
         new(xpos, ypos, pendown, orientation, pencolor)
     end

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -593,7 +593,7 @@ for e in o
           move(x, y)
           curve(x1, y1, x2, y2, x3, y3)
           strokepath()
-          (x, y) = (x3, y3) # update current point
+          (x, y) = (x3, y3) # update current point
       elseif e.element_type == Cairo.CAIRO_PATH_CLOSE_PATH
           closepath()
       else

--- a/src/colors_styles.jl
+++ b/src/colors_styles.jl
@@ -335,9 +335,9 @@ get_current_hue()
 As set by eg `sethue()`. Return an RGB colorant.
 """
 function get_current_hue()
-	return RGB(Luxor.get_current_redvalue(),
-		Luxor.get_current_greenvalue(),
-		Luxor.get_current_bluevalue())
+    return RGB(Luxor.get_current_redvalue(),
+        Luxor.get_current_greenvalue(),
+        Luxor.get_current_bluevalue())
 end
 
 """
@@ -346,8 +346,8 @@ get_current_color()
 As set by eg `setcolor()`. Return an RGBA colorant.
 """
 function get_current_color()
-	return RGBA(Luxor.get_current_redvalue(),
-		Luxor.get_current_greenvalue(),
-		Luxor.get_current_bluevalue(),
-		Luxor.get_current_alpha())
+    return RGBA(Luxor.get_current_redvalue(),
+        Luxor.get_current_greenvalue(),
+        Luxor.get_current_bluevalue(),
+        Luxor.get_current_alpha())
 end

--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -192,7 +192,7 @@ function tidysvg(fname)
     return outfile
 end
 
-# in memory:
+# in memory:
 
 Base.showable(::MIME"image/svg+xml", d::Luxor.Drawing) = d.surfacetype == :svg
 Base.showable(::MIME"image/png", d::Luxor.Drawing) = d.surfacetype == :png

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,8 +1,8 @@
 const Mesh = Cairo.CairoPattern
 
 """
-	add_mesh_patch(pattern::Mesh, bezierpath::BezierPath,
-		colors=Array{Colors.Colorant, 1})
+    add_mesh_patch(pattern::Mesh, bezierpath::BezierPath,
+        colors=Array{Colors.Colorant, 1})
 
 Add a new patch to the mesh pattern in `pattern`.
 
@@ -15,35 +15,35 @@ if necessary. At least one color should be supplied.
 Use `setmesh()` to select the mesh, which will be used to fill shapes.
 """
 function add_mesh_patch(pattern::Mesh, bezierpath::BezierPath, colors=Array{Colors.Colorant, 1})
-	Cairo.mesh_pattern_begin_patch(pattern)
-	# we must do 3 or 4 vertices, so need 2, 3, and possibly 4
-	if length(bezierpath) == 3
-		pts = bezierpath[2:3]
-		vcount = 3
-	elseif length(bezierpath) >= 4
-		pts = bezierpath[2:4]
-		vcount = 4
-	else
-		throw(error("_add_mesh_patch(): patch should provide 3 or 4 points, not $(length(bezierpath))"))
-	end
-	# use first point
-	Cairo.mesh_pattern_move_to(pattern, bezierpath[1][1].x, bezierpath[1][1].y)
-	# then get next 2 or 3
-	for bp in bezierpath
-		Cairo.mesh_pattern_curve_to(pattern, bp[2].x, bp[2].y, bp[3].x, bp[3].y, bp[4].x, bp[4].y)
-	end
+    Cairo.mesh_pattern_begin_patch(pattern)
+    # we must do 3 or 4 vertices, so need 2, 3, and possibly 4
+    if length(bezierpath) == 3
+        pts = bezierpath[2:3]
+        vcount = 3
+    elseif length(bezierpath) >= 4
+        pts = bezierpath[2:4]
+        vcount = 4
+    else
+        throw(error("_add_mesh_patch(): patch should provide 3 or 4 points, not $(length(bezierpath))"))
+    end
+    # use first point
+    Cairo.mesh_pattern_move_to(pattern, bezierpath[1][1].x, bezierpath[1][1].y)
+    # then get next 2 or 3
+    for bp in bezierpath
+        Cairo.mesh_pattern_curve_to(pattern, bp[2].x, bp[2].y, bp[3].x, bp[3].y, bp[4].x, bp[4].y)
+    end
 
-	for n in 1:vcount
-		# always use RGBA, even if RGB supplied
-		col = convert(Colors.RGBA, parse(Colors.Colorant, colors[mod1(n, length(colors))]))
-		Cairo.mesh_pattern_set_corner_color_rgba(pattern, n - 1, col.r, col.g, col.b, col.alpha)
-	end
-	Cairo.mesh_pattern_end_patch(pattern)
-	return pattern
+    for n in 1:vcount
+        # always use RGBA, even if RGB supplied
+        col = convert(Colors.RGBA, parse(Colors.Colorant, colors[mod1(n, length(colors))]))
+        Cairo.mesh_pattern_set_corner_color_rgba(pattern, n - 1, col.r, col.g, col.b, col.alpha)
+    end
+    Cairo.mesh_pattern_end_patch(pattern)
+    return pattern
 end
 
 """
-	add_mesh_patch(pattern::Mesh, plist::Array{Point}, colors=Array{Colors.Colorant, 1})
+    add_mesh_patch(pattern::Mesh, plist::Array{Point}, colors=Array{Colors.Colorant, 1})
 
 Add a new patch to the mesh pattern in `pattern`.
 
@@ -54,31 +54,31 @@ The `colors` array define the color of each corner point. Colors are reused
 if necessary. At least one color should be supplied.
 """
 function add_mesh_patch(pattern::Mesh, plist::Array{Point}, colors=Array{Colors.Colorant, 1})
-	Cairo.mesh_pattern_begin_patch(pattern)
-	# we must do 3 or 4 vertices, so need 2, 3, and possibly 4
-	if length(plist) == 3
-		pts = plist[2:3]
-		vcount = 3
-	elseif length(plist) >= 4
-		pts = plist[2:4]
-		vcount = 4
-	else
-		throw(error("_add_mesh_patch(): patch should provide 3 or 4 points, not $(length(plist))"))
-	end
-	# use first point
-	Cairo.mesh_pattern_move_to(pattern, plist[1].x, plist[1].y)
-	# then get next 2 or 3
-	for pt in pts
-		Cairo.mesh_pattern_line_to(pattern, pt.x, pt.y)
-	end
+    Cairo.mesh_pattern_begin_patch(pattern)
+    # we must do 3 or 4 vertices, so need 2, 3, and possibly 4
+    if length(plist) == 3
+        pts = plist[2:3]
+        vcount = 3
+    elseif length(plist) >= 4
+        pts = plist[2:4]
+        vcount = 4
+    else
+        throw(error("_add_mesh_patch(): patch should provide 3 or 4 points, not $(length(plist))"))
+    end
+    # use first point
+    Cairo.mesh_pattern_move_to(pattern, plist[1].x, plist[1].y)
+    # then get next 2 or 3
+    for pt in pts
+        Cairo.mesh_pattern_line_to(pattern, pt.x, pt.y)
+    end
 
-	for n in 1:vcount
-		# always use RGBA, even if RGB supplied
-		col = convert(Colors.RGBA, parse(Colors.Colorant, colors[mod1(n, length(colors))]))
-		Cairo.mesh_pattern_set_corner_color_rgba(pattern, n - 1, col.r, col.g, col.b, col.alpha)
-	end
-	Cairo.mesh_pattern_end_patch(pattern)
-	return pattern
+    for n in 1:vcount
+        # always use RGBA, even if RGB supplied
+        col = convert(Colors.RGBA, parse(Colors.Colorant, colors[mod1(n, length(colors))]))
+        Cairo.mesh_pattern_set_corner_color_rgba(pattern, n - 1, col.r, col.g, col.b, col.alpha)
+    end
+    Cairo.mesh_pattern_end_patch(pattern)
+    return pattern
 end
 
 
@@ -113,7 +113,7 @@ end
 function mesh(bezierpath::BezierPath,
               colors=Array{Colors.Colorant, 1})
     pattern = Cairo.CairoPatternMesh()
-	return add_mesh_patch(pattern, bezierpath, colors)
+    return add_mesh_patch(pattern, bezierpath, colors)
 end
 
 # old style for compatibility
@@ -152,7 +152,7 @@ end
 """
 function mesh(plist::Array{Point}, colors=Array{Colors.Colorant, 1})
     pattern = Cairo.CairoPatternMesh()
-	return add_mesh_patch(pattern, plist, colors)
+    return add_mesh_patch(pattern, plist, colors)
 end
 
 """

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1725,52 +1725,52 @@ end
 ```
 """
 function polymorph(pgon1::Array{Array{Point,1}}, pgon2::Array{Array{Point,1}}, k;
-    	samples = 100,
-    	easingfunction = easingflat,
+        samples = 100,
+        easingfunction = easingflat,
         min_k = 0.01,
         max_k = 0.99,
-		kludge = true)
+        kludge = true)
     k <= min_k && return pgon1
     k >= max_k && return pgon2
     loopcount1 = length(pgon1)
     loopcount2 = length(pgon2)
-	result = Array{Point,1}[]
-	centroid1 = centroid2 = O # kludge-y eh?
-	for i in 1:max(loopcount1, loopcount2)
-	    from_ok = to_ok = false
-	    not_empty1 = i <= loopcount1
-	    not_empty2 = i <= loopcount2
-	    if (not_empty1 && length(pgon1[i]) >= 3)
-			from_ok = true
-		end
-	    if (not_empty2 && length(pgon2[i]) >= 3)
-			to_ok = true
-		end
-	    if from_ok && to_ok
+    result = Array{Point,1}[]
+    centroid1 = centroid2 = O # kludge-y eh?
+    for i in 1:max(loopcount1, loopcount2)
+        from_ok = to_ok = false
+        not_empty1 = i <= loopcount1
+        not_empty2 = i <= loopcount2
+        if (not_empty1 && length(pgon1[i]) >= 3)
+            from_ok = true
+        end
+        if (not_empty2 && length(pgon2[i]) >= 3)
+            to_ok = true
+        end
+        if from_ok && to_ok
             # a simple morph should suffice
-			push!(result, Luxor._betweenpoly(pgon1[i], pgon2[i], k,
-				samples = samples,
-				easingfunction = easingfunction))
-			centroid1 = polycentroid(pgon1[i])
-			centroid2 = polycentroid(pgon2[i])
-	    elseif from_ok && !to_ok && kludge
+            push!(result, Luxor._betweenpoly(pgon1[i], pgon2[i], k,
+                samples = samples,
+                easingfunction = easingfunction))
+            centroid1 = polycentroid(pgon1[i])
+            centroid2 = polycentroid(pgon2[i])
+        elseif from_ok && !to_ok && kludge
             # nothing to morph to, so make something up
-			pdir = !ispolyclockwise(pgon1[i])
-			loop2 = ngon(centroid2, 0.1, reversepath = pdir, length(pgon1[i]), vertices = true)
-			push!(result, Luxor._betweenpoly(pgon1[i], loop2, k,
-				samples = samples,
-				easingfunction = easingfunction))
-			centroid1 = polycentroid(pgon1[i])
-		elseif !from_ok && to_ok && kludge
-		   # nothing to morph from, so make something up
-			pdir = !ispolyclockwise(pgon2[i])
-			loop1 = ngon(centroid1, 0.1, reversepath = pdir, length(pgon2[i]), vertices = true)
-			push!(result, Luxor._betweenpoly(loop1, pgon2[i], k,
-				samples = samples,
-				easingfunction = easingfunction))
-			centroid2 = polycentroid(pgon2[i])
-	    end
-	end
+            pdir = !ispolyclockwise(pgon1[i])
+            loop2 = ngon(centroid2, 0.1, reversepath = pdir, length(pgon1[i]), vertices = true)
+            push!(result, Luxor._betweenpoly(pgon1[i], loop2, k,
+                samples = samples,
+                easingfunction = easingfunction))
+            centroid1 = polycentroid(pgon1[i])
+        elseif !from_ok && to_ok && kludge
+           # nothing to morph from, so make something up
+            pdir = !ispolyclockwise(pgon2[i])
+            loop1 = ngon(centroid1, 0.1, reversepath = pdir, length(pgon2[i]), vertices = true)
+            push!(result, Luxor._betweenpoly(loop1, pgon2[i], k,
+                samples = samples,
+                easingfunction = easingfunction))
+            centroid2 = polycentroid(pgon2[i])
+        end
+    end
     return result
 end
 

--- a/src/text.jl
+++ b/src/text.jl
@@ -296,7 +296,7 @@ textoutlines(s::AbstractString; kwargs...) = textoutlines(s, O, kwargs...)
     textcurve(the_text, start_angle, start_radius, x_pos = 0, y_pos = 0;
           # optional keyword arguments:
           spiral_ring_step = 0,    # step out or in by this amount
-          letter_spacing = 0,      # tracking/space between chars, tighter is (-), looser is (+)
+          letter_spacing = 0,      # tracking/space between chars, tighter is (-), looser is (+)
           spiral_in_out_shift = 0, # + values go outwards, - values spiral inwards
           clockwise = true
           )
@@ -375,7 +375,7 @@ function textcurvecentered(the_text, the_angle, the_radius, center::Point;
                            baselineshift = 0
       )
     atextbox = textextents(the_text)
-    atextwidth = atextbox[3]                         # width of text
+    atextwidth = atextbox[3]                         # width of text
     if clockwise
         baselineradius = the_radius + baselineshift  # could be adjusted if we knew font height
     else

--- a/src/text.jl
+++ b/src/text.jl
@@ -602,7 +602,7 @@ function textlines(s::T where T<:AbstractString, width::Real; rightgutter=5)
     spaceleft = textwidth
     currentline = String[]
     for word in fields
-		# hyphenation can leave an empty string field
+        # hyphenation can leave an empty string field
         if word == ""
             word = " "
             push!(currentline, " ")
@@ -978,66 +978,66 @@ function textfit(s::T where T<:AbstractString, bbox::BoundingBox, maxfontsize = 
         te = textextents(lines[1])
 
         # set up our binary search
-		foundminsize = 0.5
-		foundmaxsize = maxfontsize
-		totalattempts = 20
-		attempts = 0
+        foundminsize = 0.5
+        foundmaxsize = maxfontsize
+        totalattempts = 20
+        attempts = 0
 
         # binary search for the closest fontsize that satisfies our requirements
-		while foundmaxsize - foundminsize > 0.1
-			attempts += 1
-		    if attempts > totalattempts
-		        throw(error("textfit(): couldn't fit the text with $maxfontsize maxfontsize after trying $(atttempts) times"))
-		    end
+        while foundmaxsize - foundminsize > 0.1
+            attempts += 1
+            if attempts > totalattempts
+                throw(error("textfit(): couldn't fit the text with $maxfontsize maxfontsize after trying $(atttempts) times"))
+            end
 
-			fsize = foundminsize + (foundmaxsize - foundminsize) / 2.0
-			fontsize(fsize)
+            fsize = foundminsize + (foundmaxsize - foundminsize) / 2.0
+            fontsize(fsize)
 
-			# split into lines
-		    lines = filter!(!isempty, textlines(s, width))
+            # split into lines
+            lines = filter!(!isempty, textlines(s, width))
 
-			# estimate the finish height with our current fontsize
-			# since we don't know the height well enough, just hope that putting leading
-			# between every line will work
-			estimatedfinishheight = (fsize + (100/leading)) * length(lines)
+            # estimate the finish height with our current fontsize
+            # since we don't know the height well enough, just hope that putting leading
+            # between every line will work
+            estimatedfinishheight = (fsize + (100/leading)) * length(lines)
 
-		    # estimate finish width
-		    widestline = 0
-		    for l in lines
-			   	 te = textextents(l)
-			   	 if widestline <= te[3]
-			          widestline = te[3]
-			   	 end
-		    end
+            # estimate finish width
+            widestline = 0
+            for l in lines
+                te = textextents(l)
+                if widestline <= te[3]
+                    widestline = te[3]
+                end
+            end
 
-		    # is this estimated result good enough with this font size?
-		    if estimatedfinishheight < requiredheight && widestline < boxwidth(bbox)
-			    # estimated size is too small
-			    # search for a larger font size
-		        foundminsize = fsize
-		    else
-				# estimated size is too large
-				# search for a smaller font size.
-		    	foundmaxsize = fsize
-		    end
-		end # while
+            # is this estimated result good enough with this font size?
+            if estimatedfinishheight < requiredheight && widestline < boxwidth(bbox)
+                # estimated size is too small
+                # search for a larger font size
+                foundminsize = fsize
+            else
+                # estimated size is too large
+                # search for a smaller font size.
+                foundmaxsize = fsize
+            end
+        end # while
 
         # use the most recent font size
         fontsize(fsize * (100/leading))
         lines = filter!(!isempty, textlines(s, width))
 
-		# start below the top of the box
+        # start below the top of the box
 
-		te = textextents(lines[1])
-		# we can't get the height of a text character, sadly
-		# but we can guess
-		# not all fonts will have these characters though?
-		fontheight = textextents("AA⃰gg̲")[4]
-		textpos = boxtopleft(bbox) + Point(0, max(te[4], fontheight))
+        te = textextents(lines[1])
+        # we can't get the height of a text character, sadly
+        # but we can guess
+        # not all fonts will have these characters though?
+        fontheight = textextents("AA⃰gg̲")[4]
+        textpos = boxtopleft(bbox) + Point(0, max(te[4], fontheight))
 
         for (linenumber, linetext) in enumerate(lines)
             text(linetext, textpos)
-			te = textextents(linetext)
+            te = textextents(linetext)
             textpos = Point(textpos.x, textpos.y + (max(te[4], fontheight) * (leading/100)))
         end
         # return top position, bottom position

--- a/test/boxmaptest.jl
+++ b/test/boxmaptest.jl
@@ -17,7 +17,7 @@ function boxmaptest(fname)
     for (n, t) in enumerate(tiles)
     randomhue()
 
-    #box(t, :fill) # box() would work, but BoundingBoxes are fun too
+    #box(t, :fill) # box() would work, but BoundingBoxes are fun too
 
     bb = BoundingBox(t)
     sethue("black")

--- a/test/get_path.jl
+++ b/test/get_path.jl
@@ -41,7 +41,7 @@ function get_path(str)
             # Use point interface, to make sure that is also tested
             curve(Point(x1, y1), Point(x2, y2), Point(x3, y3))
             strokepath()
-            (x, y) = (x3, y3) # update current point
+            (x, y) = (x3, y3) # update current point
         elseif e.element_type == CAIRO_PATH_CLOSE_PATH
             closepath()
         else

--- a/test/get_path_flat.jl
+++ b/test/get_path_flat.jl
@@ -40,7 +40,7 @@ function get_path_flat(str)
             move(x, y)
             curve(x1, y1, x2, y2, x3, y3)
             strokepath()
-            (x, y) = (x3, y3) # update current point
+            (x, y) = (x3, y3) # update current point
         elseif e.element_type == CAIRO_PATH_CLOSE_PATH
             closepath()
         else

--- a/test/heart-julia.jl
+++ b/test/heart-julia.jl
@@ -32,7 +32,7 @@ function background_text(str_array)
 end
 
 function heart()
-    move(127, 1) # damn, it's offset from 0/0, who drew this :/
+    move(127, 1) # damn, it's offset from 0/0, who drew this :/
     curve(134.2, -6.5, 134.2, -6.5, 156.1, -29.6)
     curve(185.8, -60.5, 198.1, -74.3, 213.7, -95.3)
     curve(240.4, -131, 253.3, -163.7, 253.3, -194.9)
@@ -75,7 +75,7 @@ end
 function outlined_heart()
     gsave()
     scale(1.2, 1.2)
-    translate(-127, -30) # must fix that x-offset one day
+    translate(-127, -30) # must fix that x-offset one day
     heart_with_julias()
     heart()
     setline(4)
@@ -91,7 +91,7 @@ function julia_heart(fname)
 
     origin()
     background("black")
-    namelist = map(x -> string(x), names(Base)) # list of names in Base.
+    namelist = map(x -> string(x), names(Base)) # list of names in Base.
 
     background_text(namelist)
     for n in 1:5

--- a/test/matrix-tests.jl
+++ b/test/matrix-tests.jl
@@ -57,14 +57,14 @@ function matrix_tests(fname)
 
     original_matrix = getmatrix()
 
-    # absolute position 200, 250 relative to top left origin (0, 0)
+    # absolute position 200, 250 relative to top left origin (0, 0)
     setmatrix([1, 0, 0, 1, 200, 250.0])
     sethue("red")
     fontsize(20)
     text("hello world")
 
     sethue("green")
-    # absolute position 400, 500 from top left origin (0, 0)
+    # absolute position 400, 500 from top left origin (0, 0)
     setmatrix([1, 0, 0, 1, 400, 500.0])
     text("hello world")
 

--- a/test/matrix-tests.jl
+++ b/test/matrix-tests.jl
@@ -12,12 +12,12 @@ Random.seed!(42)
 function matrix_tests(fname)
     # matrix tests
 
-    # translate(dx, dy) =	transform([1,  0, 0,  1, dx, dy])                shift by
-    # scale(fx, fy)    =    transform([fx, 0, 0, fy,  0, 0])                 scale by
-    # rotate(A)        =    transform([c, s, -c, c,   0, 0])                 rotate to A radians
-    # x-skew(a)        =    transform([1,  0, tan(a), 1,   0, 0])            xskew by A
-    # y-skew(a)        =    transform([1, tan(a), 0, 1, 0, 0])               yskew by A
-    # flip HV          =    transform([fx, 0, 0, fy, cx(*1-fx), cy* (fy-1)]) flip
+    # translate(dx, dy) =   transform([1,  0, 0,  1, dx, dy])                shift by
+    # scale(fx, fy)     =   transform([fx, 0, 0, fy,  0, 0])                 scale by
+    # rotate(A)         =   transform([c, s, -c, c,   0, 0])                 rotate to A radians
+    # x-skew(a)         =   transform([1,  0, tan(a), 1,   0, 0])            xskew by A
+    # y-skew(a)         =   transform([1, tan(a), 0, 1, 0, 0])               yskew by A
+    # flip HV           =   transform([fx, 0, 0, fy, cx(*1-fx), cy* (fy-1)]) flip
 
     Drawing(1000, 1000, fname)
 

--- a/test/point-inside-polygon.jl
+++ b/test/point-inside-polygon.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 
 # testing isinside(), is point inside polygon
-# all the random points are drawn only if they're inside one of the polygons
+# all the random points are drawn only if they're inside one of the polygons
 
 using Luxor
 
@@ -35,7 +35,7 @@ function point_inside_polygon(fname)
             randomsize = rand(4:12)
             bp = bounding_b(pt.x, pt.y, randomsize)
             # check that all four corners of a 5x5 bounding box are inside this polygon
-            # slow but this is Julia so it's still quick...
+            # slow but this is Julia so it's still quick...
             if isinside(bp[1], pol) && isinside(bp[2], pol) && isinside(bp[3], pol) && isinside(bp[4], pol)
                 randomhue()
                 circle(pt.x, pt.y, randomsize, :fill)

--- a/test/polygon-centroid-sort-test.jl
+++ b/test/polygon-centroid-sort-test.jl
@@ -46,7 +46,7 @@ function drawpoly(p, x, y, counter)
     circle(cp, 5, :fill)
     text(string(counter), cp.x, cp.y)
 
-    # highlight cases where centroid isn't inside poly. Might be an error...
+    # highlight cases where centroid isn't inside poly. Might be an error...
     if ! isinside(cp, psort)
         gsave()
         setdash("dotted")

--- a/test/polygon-test.jl
+++ b/test/polygon-test.jl
@@ -113,7 +113,7 @@ function polygon_test(fname)
     # fill, then clip to heptagon
     setcolor("lightcyan")
     setline(3)
-    ngon(0, 0, 270, 7, 0, :fillpreserve) # fill it
+    ngon(0, 0, 270, 7, 0, :fillpreserve) # fill it
     sethue("orange")
     strokepreserve()                     # stroke it
     clip()                               # then use to clip

--- a/test/sierpinski-svg.jl
+++ b/test/sierpinski-svg.jl
@@ -31,7 +31,7 @@ function drawsierpinski(fname, n)
   background("ivory")
   circle(O, 75, :clip)
   my_points = ngon(O, 150, 3, -pi/2, vertices=true)
-  depth = 8 # 12 is ok, 20 is right out
+  depth = 8 # 12 is ok, 20 is right out
   sierpinskitriangle(my_points, n)
   @test finish() == true
 end

--- a/test/sierpinski.jl
+++ b/test/sierpinski.jl
@@ -31,7 +31,7 @@ function draw(fname, n)
   background("ivory")
   circle(O, 75, :clip)
   my_points = ngon(O, 150, 3, -pi/2, vertices=true)
-  depth = 8 # 12 is ok, 20 is right out
+  depth = 8 # 12 is ok, 20 is right out
   sierpinski(my_points, n)
   @test finish() == true
 end

--- a/test/simplify-polygons.jl
+++ b/test/simplify-polygons.jl
@@ -49,7 +49,7 @@ function test(pagewidth, pageheight)
 end
 
 function simplify_poly(fname)
-    pagewidth  = 1190.0 # points
+    pagewidth  = 1190.0 # points
     pageheight = 1684.0 # points
     Drawing(pagewidth, pageheight, fname)
     sinecurves()

--- a/test/text-path-clipping.jl
+++ b/test/text-path-clipping.jl
@@ -13,14 +13,14 @@ function text_path_clip(fname)
     origin()
     background("darkslategray3")
 
-    fontsize(600) # big text to use for clipping
+    fontsize(600) # big text to use for clipping
     fontface("Agenda-Black")
     str = "julia" # string to be clipped
-    w, h = textextents(str)[3:4] # get width and height
+    w, h = textextents(str)[3:4] # get width and height
 
     translate(-(currentwidth/2) + 50, -(currentheight/2) + h)
 
-    textpath(str) # make text into a path
+    textpath(str) # make text into a path
     setline(3)
     setcolor("black")
     fillpreserve() # fill but keep
@@ -28,7 +28,7 @@ function text_path_clip(fname)
 
     fontface("Monaco")
     fontsize(10)
-    namelist = map(x->string(x), names(Base)) # list of names in Base.
+    namelist = map(x->string(x), names(Base)) # list of names in Base.
 
     x = -20
     y = -h

--- a/test/tiling-images.jl
+++ b/test/tiling-images.jl
@@ -57,7 +57,7 @@ background("grey50")
 setopacity(0.5)
 pagetiles = Tiler(width, height, 8, 8, margin=50)
 for (pos, n) in pagetiles
-  if n > length(imagelist) # run out of images
+  if n > length(imagelist) # run out of images
     break
   end
   addimagetile(imagelist[n], pos.x, pos.y, pagetiles.tilewidth, pagetiles.tileheight, cropping=true)

--- a/test/turtle-test.jl
+++ b/test/turtle-test.jl
@@ -20,7 +20,7 @@ function test_turtles(fname)
     origin()
     background("black")
 
-    # let's have two turtles
+    # let's have two turtles
     raphael = Turtle(0, 0, true, 0, (1.0, 0.25, 0.25))
     michaelangelo = Turtle(0, 0, true, 0, (1.0, 0.25, 0.25))
 


### PR DESCRIPTION
This PR replaces characters `"\t"` and `"'\U00A0'"` with normal white spaces. (x-ref https://github.com/JuliaGraphics/Luxor.jl/pull/209#discussion_r825274761)

**Before this PR**
http://juliagraphics.github.io/Luxor.jl/dev/howto/createdrawings/#Using-Pluto

![image](https://user-images.githubusercontent.com/7488140/169673591-b6773cf7-67a8-439f-81aa-3e88ed7ada38.png)

**After this PR**
![image](https://user-images.githubusercontent.com/7488140/169673628-504da09b-6317-48b0-a882-33b520ab7dc8.png)


