### PR TITLE
Add methods to `Base.zero`

### DIFF
--- a/src/point.jl
+++ b/src/point.jl
@@ -16,6 +16,8 @@ end
 O is a shortcut for the current origin, `0/0`
 """
 const O = Point(0, 0)
+Base.zero(::Type{Point}) = O
+Base.zero(::Point) = O
 
 # basics
 +(z::Number, p1::Point) = Point(p1.x + z, p1.y + z)

--- a/test/point-arithmetic.jl
+++ b/test/point-arithmetic.jl
@@ -20,6 +20,12 @@ function general_tests()
     @test Point((1, 2)) == Point(1, 2)
     @test [Point(3, 1), Point(4.0, 1.0), Point(2//3,3//4)] == Point.([(3.0, 1.0), (4, 1), (2//3,3//4)])
 
+    # origin point with Base.zero
+    @test zero(Point) == zero(Point(1,2)) == O
+    @test zeros(Point, 5) == fill(O, 5)
+    @test iszero(O)
+    @test !iszero(Point(1,2))
+
     # is point/4 inside a box
     # a: we now have to wrap arguments with Ref() to ensure they  broadcast as scalar
     @test isinside(Ref(pt1) ./ 4, box(O, 10, 10, vertices=true))


### PR DESCRIPTION
This PR fixes #221.

```julia
julia> using Luxor

julia> zero(Point)
Point(0.0, 0.0)

julia> zero(Point(1,2))
Point(0.0, 0.0)

julia> zeros(Point, 4)
4-element Vector{Point}:
 Point(0.0, 0.0)
 Point(0.0, 0.0)
 Point(0.0, 0.0)
 Point(0.0, 0.0)

julia> iszero(O)
true

julia> iszero(Point(1,2))
false
```