### PR TITLE
Small fix in points from tuples example

### DIFF
--- a/docs/src/explanation/basics.md
+++ b/docs/src/explanation/basics.md
@@ -129,7 +129,7 @@ You can also create points from tuples:
 julia> Point((1.0, 14))
 Point(1.0, 14.0)
 
-julia> plist = (1.0, 2.0), (-10, 10), (14.2, 15.4));
+julia> plist = (1.0, 2.0), (-10, 10), (14.2, 15.4);
 
 julia> Point.(plist)
 3-element Array{Point,1}:


### PR DESCRIPTION
There's an extra paren that seems to have slipped into this example which raises an error. This PR removes that and now the example works as intended.
![image](https://user-images.githubusercontent.com/14952412/173658887-b4aaa81a-2ced-4449-9c18-9a9056d3c093.png)
