### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rsvg = "c4c386cf-5103-5370-be45-f3a111cca3b8"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Cairo = "0.7, 0.8, 1.0"
@@ -26,7 +26,7 @@ Juno = "0.7, 0.8"
 LaTeXStrings = "1.1, 1.2, 1.3"
 Requires = "1, 1.1, 1.2, 1.3"
 Rsvg = "1.0"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.6"
 
 [extras]

--- a/src/drawings.jl
+++ b/src/drawings.jl
@@ -153,7 +153,7 @@ end
 # stored as item at index _current_drawing_index() in a constant global array
 
 function _get_current_drawing_save()
-    # check if drawing is not corrupted (has been observed using SnoopPrecompile)
+    # check if drawing is not corrupted (has been observed using PrecompileTools)
     #   checking fields:
     #     surface::CairoSurface
     #     cr::CairoSurface

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,8 +1,8 @@
-import SnoopPrecompile
+import PrecompileTools
 
-@info "SnoopPrecompile is analyzing Luxor.jl code..."
+@info "PrecompileTools is analyzing Luxor.jl code..."
 
-SnoopPrecompile.@precompile_all_calls begin
+PrecompileTools.@compile_workload begin
     ngon(O, 100, 3, vertices=true)
     @draw circle(1.0, 1.2, 1.9, action=:fill)
     noise(1)


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
