### PR TITLE
Remove precompile info to prevent precompile warning

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,5 @@
 import PrecompileTools
 
-@info "PrecompileTools is analyzing Luxor.jl code..."
-
 PrecompileTools.@compile_workload begin
     ngon(O, 100, 3, vertices=true)
     @draw circle(1.0, 1.2, 1.9, action=:fill)


### PR DESCRIPTION
With Luxor v3.7.0 I see
```
(@v1.9) pkg> precompile
Precompiling project...
  165 dependencies successfully precompiled in 481 seconds. 304 already precompiled.
  1 dependency had warnings during precompilation:
┌ Luxor [ae8d54c2-7ccd-5906-9d76-62fc9837b5bc]
│  [ Info: SnoopPrecompile is analyzing Luxor.jl code...
└
```

Note: SnoopPrecompile has been miograted to PrecompileTools in https://github.com/JuliaGraphics/Luxor.jl/pull/263 , but there has not been a release.

I suggest removing the line
```
@info "PrecompileTools is analyzing Luxor.jl code..."
```
from https://github.com/JuliaGraphics/Luxor.jl/blob/master/src/precompile.jl 