### PR TITLE
Divide a circle into four arcs for more precision

### DIFF
--- a/src/curves.jl
+++ b/src/curves.jl
@@ -5,7 +5,10 @@ function circle(x::Real, y::Real, r::Real;
     if action != :path
         newpath()
     end
-    Cairo.arc(_get_current_cr(), x, y, r, 0, 2pi)
+    Cairo.arc(_get_current_cr(), x, y, r, 0, pi/2)
+    Cairo.arc(_get_current_cr(), x, y, r, pi/2, pi)
+    Cairo.arc(_get_current_cr(), x, y, r, pi, 3pi/2)
+    Cairo.arc(_get_current_cr(), x, y, r, 3pi/2, 2pi)
     do_action(action)
     return (Point(x, y) - (r, r), Point(x, y) + (r, r))
 end


### PR DESCRIPTION
This PR fixes https://github.com/JuliaGraphics/Luxor.jl/issues/268.

* The number of control points still depends on the radius of the circle. For example, `circle(Point(0,0), 500)` consists of eight Beziser segments. (Before this PR, it was six segments)
  * This is because Cairo divides the target arcs into Bezier segments based on some `atol`.
  * I think the best way is adding `atol` and `rtol` to `Luxor.circle` as keyword arguments and approximate the target circle in this package. But I'm not sure that kind of flexibility is desired.
* Some other functions such as `pie` and `arc2r` still have the precision issue.
* Checking the precision of the circle would be complicated, so I have not added tests for this change.
