### PR TITLE
Add keyword argument `close` to function polysmooth

### DIFF
--- a/test/polysmooth-tests.jl
+++ b/test/polysmooth-tests.jl
@@ -23,6 +23,7 @@ function star_test(fname)
            p = star(pos, tiles.tilewidth/2 - 10, randomsides, randomratio, 0, vertices=true)
            prettypoly(p, close=true, :stroke)
            polysmooth(p, randomsmoothing, :fill, debug=true)
+           polysmooth(p, randomsmoothing, :fill, debug=true, close=false)
      end
     @test finish() == true
     println("...finished test: output in $(fname)")


### PR DESCRIPTION
![image](https://github.com/JuliaGraphics/Luxor.jl/assets/6257240/001b916f-d219-4af9-9ff2-1dc14fb16e1d)

```julia
using Luxor

@drawsvg begin
	background("white")
	polysmooth([Point(0, 0), Point(0, 100), Point(100, 100), Point(100, 0)], 5, :stroke; close=false)
end 300 300
```