### PR TITLE
Fix intersect lines and polysmooth function

### DIFF
--- a/src/point.jl
+++ b/src/point.jl
@@ -327,9 +327,9 @@ function ispointonline(pt::Point, pt1::Point, pt2::Point;
 
     # point on the line
     if (abs(dxl) >= abs(dyl))
-        return dxl > 0 ? pt1.x <= pt.x && pt.x <= pt2.x : pt2.x <= pt.x && pt.x <= pt1.x
+        return dxl > 0 ? pt1.x <= pt.x+atol && pt.x <= pt2.x+atol : pt2.x <= pt.x+atol && pt.x <= pt1.x+atol
     else
-        return dyl > 0 ? pt1.y <= pt.y && pt.y <= pt2.y : pt2.y <= pt.y && pt.y <= pt1.y
+        return dyl > 0 ? pt1.y <= pt.y+atol && pt.y <= pt2.y+atol : pt2.y <= pt.y+atol && pt.y <= pt1.y+atol
     end
 end
 

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -393,13 +393,16 @@ function polysmooth(points::Array{Point,1}, radius, action::Symbol; debug = fals
     # need to close by joining to first point
     if close
         push!(temppath, temppath[1])
+        temppath[1] = (:move, temppath[1][2])
     else
-        pushfirst!(temppath, (:line, points[1]))
+        pushfirst!(temppath, (:move, points[1]))
         push!(temppath, (:line, points[end]))
     end
     # draw the path
     for (c, p) in temppath
-        if c == :line
+        if c == :move
+            move(p)
+        elseif c == :line
             line(p)    # add line segment
         elseif c == :arc
             arc(p...)  # add clockwise arc segment


### PR DESCRIPTION
This PR fixes the following two bugs.

1. The polysmooth has one extra line connecting to it.
2. The `intersectlinepoly` can not find intersection in some corner case.