### PR TITLE
Update `BezierPath` constructor

### DIFF
--- a/src/bezierpath.jl
+++ b/src/bezierpath.jl
@@ -49,7 +49,7 @@ mutable struct BezierPath <: AbstractArray{BezierPathSegment,1}
 end
 
 BezierPath(bps::BezierPathSegment) = BezierPath([bps])
-BezierPath() = BezierPath([])
+BezierPath() = BezierPath(BezierPathSegment[])
 
 Base.size(bp::BezierPath) = size(bp.segments)
 Base.length(bp::BezierPath) = length(bp.segments)


### PR DESCRIPTION
This is a slight performance improvement, but it would be better to avoid `Any[]` in the constructor.

**Before this PR**
```julia
julia> using Luxor, BenchmarkTools

julia> @benchmark BezierPath()
BenchmarkTools.Trial: 10000 samples with 981 evaluations.
 Range (min … max):  64.005 ns …  3.877 μs  ┊ GC (min … max): 0.00% … 95.72%
 Time  (median):     66.467 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   74.230 ns ± 79.459 ns  ┊ GC (mean ± σ):  4.55% ±  4.48%

  ▃██▆▃▂▁▁  ▁▆▆▄▂▁                                            ▂
  █████████▇█████████▇▇▇▇▇▆▇▇▅▆▆▆▆▇▇█▇▇▇▇▆▆▆▅▆▄▄▅▅▄▆▅▄▄▅▄▄▄▃▄ █
  64 ns        Histogram: log(frequency) by time       119 ns <

 Memory estimate: 112 bytes, allocs estimate: 3.
```

**After this PR**
```julia
julia> using Luxor, BenchmarkTools

julia> @benchmark BezierPath()
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  29.151 ns …  2.820 μs  ┊ GC (min … max): 0.00% … 97.14%
 Time  (median):     31.849 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   35.803 ns ± 51.047 ns  ┊ GC (mean ± σ):  4.30% ±  3.33%

  ▂▄▇██▇▅▃▂▁▄▅▄▂ ▁                              ▁             ▂
  ███████████████████▇█▇▇▇▆▆▄▆▆▅▃▅▄▃▅▃▄▅▄▄▅▄▆██████▇▆▆▆▇▇▇▇▆▆ █
  29.2 ns      Histogram: log(frequency) by time      64.1 ns <

 Memory estimate: 64 bytes, allocs estimate: 2.
```