### PR TITLE
Use `julia-repl` code block

### DIFF
--- a/src/bezierpath.jl
+++ b/src/bezierpath.jl
@@ -746,7 +746,7 @@ Returns a tuple of two BezierPathSegments, the 'lower' one
 
 ## Example
 
-```julia
+```julia-repl
 julia> bps = BezierPathSegment(ngon(O, 200, 4, vertices=true)...)
 4-element BezierPathSegment:
  Point(1.2246467991473532e-14, 200.0)

--- a/src/point.jl
+++ b/src/point.jl
@@ -72,7 +72,7 @@ Base.length(::Point) = 2
 
 Transform a point `pt` by the 3×3 matrix `m`.
 
-```julia
+```julia-repl
 julia> M = [2 0 0; 0 2 0; 0 0 1]
 3×3 Matrix{Int64}:
  2  0  0


### PR DESCRIPTION
Some `jldoctest` were replaced with `julia` in https://github.com/JuliaGraphics/Luxor.jl/commit/5fc74172c17a951b8e089c9b5ee1368230bb8aff. This PR replaces `julia` with `julia-repl`.