### PR TITLE
Update precompile.jl

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -21,4 +21,5 @@ PrecompileTools.@compile_workload begin
     randomhue()
     textoutlines("snoopy", Point(10, 10), action=:path)
     fillpath()
+    _reset_all_drawings()
 end


### PR DESCRIPTION
fix #321

The issue are some Cairo remnants from the precompile step, called when using Luxor. I do not understand the exact details, because I don't want to delve deeper into precompile. Somehow it seems that I knew something when implementing things, because function _reset_all_drawings() exist, which, if called as last command in precompile.jl, resolves the issue.